### PR TITLE
Custom DNS server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,4 @@ services:
           CLOUDNS_DOMAIN: domain.name
           CLOUDNS_TOKEN: token_generated_by_web_for_target_domain
           CLOUDNS_INTERVAL: 1800000
+          CLOUDNS_DNS_SERVER: 8.8.8.8

--- a/index.js
+++ b/index.js
@@ -1,9 +1,13 @@
-const dns = require('dns');
 const https = require('https');
+const { Resolver } = require('dns');
 
 const domain = process.env.CLOUDNS_DOMAIN; 
 const token = process.env.CLOUDNS_TOKEN;
 const interval = process.env.CLOUDNS_INTERVAL || 30 * 60 * 1000;
+const dnsServer = process.env.CLOUDNS_DNS_SERVER || '8.8.8.8';
+
+const resolver = new Resolver();
+resolver.setServers([dnsServer]);
 
 function callClouDNSUpdate(token) {
   return new Promise((resolve, reject) => {
@@ -26,7 +30,7 @@ function callClouDNSUpdate(token) {
 
 function getCurrentIP(domain) {
   return new Promise((resolve, reject) => {
-    dns.lookup(domain, (err, currentIp) => {
+    resolver.resolve4(domain, (err, currentIp) => {
       if (err) {
         reject(err);
       } else {

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function updateIP() {
     console.log(`Real IP is ${realIP}`);
     return getCurrentIP(domain).then(currentIP => {
       console.log(`Current IP for ${domain} is ${currentIP}`);
-      if (currentIP !== realIP) {
+      if (currentIP != realIP) {
         return callClouDNSUpdate(token).then(response => {
           console.log(`IP ${realIP} updated successfully for ${domain}: ${response}`);
         });


### PR DESCRIPTION
# What?
Support for using custom DNS server for current IP resolution.

# Why?
According to issue #5 sometimes is needed using a specific external server for that.

# How?
Replaces dns.lookup(...) method with Resolver.resolve4(...).
Using a custom Resolver we can set the specific DNS server.
Also appends a new environment variable called CLOUDNS_DNS_SERVER with a default value (8.8.8.8).

**Extra change**
Fixes IP comparison for changes detection.